### PR TITLE
Fix vim initial input

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -9,7 +9,7 @@ set tabstop=4
 set shiftwidth=4
 set noswapfile
 set title
-set ttimeoutlen=0
+set ttimeoutlen=10
 
 noremap k gk
 noremap j gj

--- a/init.vim
+++ b/init.vim
@@ -10,7 +10,7 @@ set shiftwidth=4
 set expandtab
 set noswapfile
 set title
-set ttimeoutlen=0
+set ttimeoutlen=10
 
 noremap k gk
 noremap j gj


### PR DESCRIPTION
`git rebase`などでエディタを開いた際、最初の1文字目が`g`になるのを修正