### PR TITLE
add watcherExclude for performance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,11 @@
     "files.autoGuessEncoding": true,
     "explorer.confirmDragAndDrop": false,
     "workbench.startupEditor": "none",
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/*/**": true
+    },
 
     // not supported in EditorConfig
     "files.trimFinalNewlines": true,


### PR DESCRIPTION
`node_module`や`.git`の中身を、あらかじめvscodeが読み込む機能をoffにした。
多分軽くなった。